### PR TITLE
Upgraded shadow plugin to 5.1.0 to support Gradle 5.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath "io.micronaut.docs:micronaut-docs-asciidoc-extensions:$micronautDocsVersion"
         classpath "io.micronaut.docs:micronaut-docs-gradle-plugins:$micronautDocsVersion"
         classpath "io.spring.nohttp:nohttp-gradle:0.0.2.RELEASE"
+        classpath "com.github.jengelman.gradle.plugins:shadow:5.1.0"
     }
 }
 


### PR DESCRIPTION
The project fails its build because the shadow plugin does not support Gradle 5.x. The fix is to upgrade the shadow plugin to the latest version.

```
$ ./gradlew build
Starting a Gradle Daemon, 2 incompatible Daemons could not be reused, use --status for details

FAILURE: Build failed with an exception.

* What went wrong:
Method com/github/jengelman/gradle/plugins/shadow/internal/DependencyFileCollection.getBuildDependencies()Lorg/gradle/api/tasks/TaskDependency; is abstract

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.5-rc-2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 22s
```