### PR TITLE
Update snapshot documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See also the [Predator Announcement](https://objectcomputing.com/news/2019/07/18
 
 <!--- See the [Documentation](https://micronaut-projects.github.io/micronaut-grpc/latest/guide) for more information. -->
 
-See the [Snapshot Documentation](https://micronaut-projects.github.io/micronaut-predator/snapshot/guide) for the current development docs.
+See the [Snapshot Documentation](https://micronaut-projects.github.io/micronaut-predator/snapshot/guide/) for the current development docs.
 
 ## Examples
 


### PR DESCRIPTION
Without the trailing slash, there's a redirect to http://predator.micronaut.io/snapshot/guide instead, which gives a 404.
With the trailing slash, we can access the guide.