### PR TITLE
[Issue #24] Added jackson annotations to make Page deserializable

### DIFF
--- a/predator-model/build.gradle
+++ b/predator-model/build.gradle
@@ -6,6 +6,8 @@ dependencies {
 	compile "io.micronaut:micronaut-aop:$micronautVersion"
 	compile "io.reactivex.rxjava2:rxjava:2.2.6"
 	testCompile "io.micronaut:micronaut-inject-java-test:$micronautVersion"
+	compileOnly "com.fasterxml.jackson.core:jackson-annotations"
+	testCompile "com.fasterxml.jackson.core:jackson-databind"
 }
 tasks.withType(GroovyCompile) {
 	groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')

--- a/predator-model/src/main/java/io/micronaut/data/model/DefaultPage.java
+++ b/predator-model/src/main/java/io/micronaut/data/model/DefaultPage.java
@@ -16,6 +16,7 @@
 package io.micronaut.data.model;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Default implementation of {@link Page}.
@@ -42,5 +43,31 @@ class DefaultPage<T> extends DefaultSlice<T> implements Page<T> {
     @Override
     public long getTotalSize() {
         return totalSize;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultPage)) {
+            return false;
+        }
+        DefaultPage<?> that = (DefaultPage<?>) o;
+        return totalSize == that.totalSize && super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalSize, super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultPage{" +
+                "totalSize=" + totalSize +
+                ",content=" + getContent() +
+                ",pageable=" + getPageable() +
+                '}';
     }
 }

--- a/predator-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
+++ b/predator-model/src/main/java/io/micronaut/data/model/DefaultPageable.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Introspected;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.validation.constraints.Min;
+import java.util.Objects;
 
 /**
  * The default pageable implementation.
@@ -69,5 +70,33 @@ final class DefaultPageable implements Pageable {
     @Override
     public Sort getSort() {
         return sort;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultPageable)) {
+            return false;
+        }
+        DefaultPageable that = (DefaultPageable) o;
+        return max == that.max &&
+                number == that.number &&
+                Objects.equals(sort, that.sort);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(max, number, sort);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultPageable{" +
+                "max=" + max +
+                ", number=" + number +
+                ", sort=" + sort +
+                '}';
     }
 }

--- a/predator-model/src/main/java/io/micronaut/data/model/DefaultSlice.java
+++ b/predator-model/src/main/java/io/micronaut/data/model/DefaultSlice.java
@@ -21,6 +21,7 @@ import io.micronaut.core.util.CollectionUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Default implementation of {@link Slice}.
@@ -55,5 +56,31 @@ class DefaultSlice<T> implements Slice<T> {
     @Override
     public Pageable getPageable() {
         return pageable;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultSlice)) {
+            return false;
+        }
+        DefaultSlice<?> that = (DefaultSlice<?>) o;
+        return Objects.equals(content, that.content) &&
+                Objects.equals(pageable, that.pageable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content, pageable);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultSlice{" +
+                "content=" + content +
+                ", pageable=" + pageable +
+                '}';
     }
 }

--- a/predator-model/src/main/java/io/micronaut/data/model/Page.java
+++ b/predator-model/src/main/java/io/micronaut/data/model/Page.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.data.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import javax.annotation.Nonnull;
@@ -34,6 +37,7 @@ import java.util.stream.Collectors;
  * @author graemerocher
  * @since 1.0.0
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Page<T> extends Slice<T> {
 
     Page<?> EMPTY = new DefaultPage<>(Collections.emptyList(), Pageable.unpaged(), 0);
@@ -69,10 +73,14 @@ public interface Page<T> extends Slice<T> {
      * @param content The content
      * @param pageable The pageable
      * @param totalSize The total size
-     * @param <T2> The generic type
+     * @param <T> The generic type
      * @return The slice
      */
-    static @NonNull <T2> Page<T2> of(@NonNull List<T2> content, @NonNull Pageable pageable, long totalSize) {
+    @JsonCreator
+    static @NonNull <T> Page<T> of(
+            @JsonProperty("content") @NonNull List<T> content,
+            @JsonProperty("pageable") @NonNull Pageable pageable,
+            @JsonProperty("totalSize") long totalSize) {
         return new DefaultPage<>(content, pageable, totalSize);
     }
 

--- a/predator-model/src/main/java/io/micronaut/data/model/Pageable.java
+++ b/predator-model/src/main/java/io/micronaut/data/model/Pageable.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.data.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.annotation.Introspected;
@@ -29,6 +32,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @Introspected
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Pageable extends Sort {
 
     /**
@@ -159,7 +163,11 @@ public interface Pageable extends Sort {
      * @param sort the sort
      * @return The pageable
      */
-    static @NonNull Pageable from(int number, int size, @Nullable Sort sort) {
+    @JsonCreator
+    static @NonNull Pageable from(
+            @JsonProperty("number") int number,
+            @JsonProperty("size") int size,
+            @JsonProperty("sort") @Nullable Sort sort) {
         return new DefaultPageable(number, size, sort);
     }
 

--- a/predator-model/src/main/java/io/micronaut/data/model/Slice.java
+++ b/predator-model/src/main/java/io/micronaut/data/model/Slice.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.data.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import javax.annotation.Nonnull;
@@ -33,6 +35,7 @@ import java.util.stream.Collectors;
  * @author graemerocher
  * @since 1.0.0
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Slice<T> extends Iterable<T> {
 
     /**
@@ -90,6 +93,7 @@ public interface Slice<T> extends Iterable<T> {
     /**
      * @return The sort
      */
+    @JsonIgnore
     default @NonNull Sort getSort() {
         return getPageable();
     }

--- a/predator-model/src/main/java/io/micronaut/data/model/Sort.java
+++ b/predator-model/src/main/java/io/micronaut/data/model/Sort.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.data.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.util.ArgumentUtils;
@@ -29,6 +32,7 @@ import java.util.Objects;
  * @author graemerocher
  * @since 1.0
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface Sort {
 
     /**
@@ -86,7 +90,9 @@ public interface Sort {
      * @param orderList The order list
      * @return The sort
      */
-    static @NonNull Sort of(@Nullable List<Order> orderList) {
+    @JsonCreator
+    static @NonNull Sort of(
+            @JsonProperty("orderBy") @Nullable List<Order> orderList) {
         if (CollectionUtils.isEmpty(orderList)) {
             return UNSORTED;
         }
@@ -115,7 +121,11 @@ public interface Sort {
          * @param direction The direction
          * @param ignoreCase Whether to ignore case
          */
-        public Order(@NonNull String property, @NonNull Direction direction, boolean ignoreCase) {
+        @JsonCreator
+        public Order(
+                @JsonProperty("property") @NonNull String property,
+                @JsonProperty("direction") @NonNull Direction direction,
+                @JsonProperty("ignoreCase") boolean ignoreCase) {
             ArgumentUtils.requireNonNull("direction", direction);
             ArgumentUtils.requireNonNull("property", property);
             this.direction = direction;

--- a/predator-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
+++ b/predator-model/src/test/groovy/io/micronaut/data/model/PageSpec.groovy
@@ -15,6 +15,10 @@
  */
 package io.micronaut.data.model
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -52,5 +56,37 @@ class PageSpec extends Specification {
         newPage.content == [2,3,4,5,6]
         newPage.totalSize == 14
         newPage.size == 5
+    }
+
+    void "test serialization and deserialization of a page"() {
+        def page = Page.of([new Dummy(
+                propertyOne: "value one",
+                propertyTwo: 1L,
+                propertyThree: new BigDecimal("1.00")
+        ), new Dummy(
+                propertyOne: "value two",
+                propertyTwo: 2L,
+                propertyThree: new BigDecimal("2.00")
+        ), new Dummy(
+                propertyOne: "value three",
+                propertyTwo: 3L,
+                propertyThree: new BigDecimal("3.00")
+        )], Pageable.from(0, 3), 14)
+        def mapper = new ObjectMapper()
+
+        when:
+        def json = mapper.writeValueAsString(page)
+
+        then:
+        def deserializedPage = mapper.readValue(json, new TypeReference<Page<Dummy>>() {})
+        deserializedPage == page
+    }
+
+    @EqualsAndHashCode
+    @ToString
+    static class Dummy {
+        String propertyOne
+        Long propertyTwo
+        BigDecimal propertyThree
     }
 }


### PR DESCRIPTION
I added some jackson annotations, equals/hashCode/toString on Page, Size, Sort, Order, etc

Note: I am not sure whether to make a Jackson Module or to annotate directly, I just went for the more straight forward one of annotating directly. Then I just made the jackson-annotation dependency compileOnly. Kindly advice if this approach needs to be changed :)
