### PR TITLE
Log queries consistently, even when it's a custom JDBC construct

### DIFF
--- a/predator-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
+++ b/predator-jdbc/src/main/java/io/micronaut/data/jdbc/operations/DefaultJdbcRepositoryOperations.java
@@ -567,6 +567,9 @@ public class DefaultJdbcRepositoryOperations extends AbstractSqlRepositoryOperat
     public <R> R prepareStatement(@NonNull String sql, @NonNull PreparedStatementCallback<R> callback) {
         ArgumentUtils.requireNonNull("sql", sql);
         ArgumentUtils.requireNonNull("callback", callback);
+        if (PredatorSettings.QUERY_LOG.isDebugEnabled()) {
+            PredatorSettings.QUERY_LOG.debug("Executing Query: {}", sql);
+        }
         try {
             return callback.call(transactionOperations.getConnection().prepareStatement(sql));
         } catch (SQLException e) {


### PR DESCRIPTION
As I'm starting to use Predator, I found I had become dependent on this logback.xml setting:

`<logger name="io.micronaut.data.query" level="DEBUG"/>`

But then I got stumped because I was finding that when I did my own custom stuff with `JdbcOperations`, I wasn't seeing any queries. At first it made me think there was some issue about not actually executing the queries and I was using the API wrong, but then I realized it was actually executing and it simply wasn't _logging_.

Hence, I believe this little change would be helpful.